### PR TITLE
cmd-keypad: Exit also on key press on serial/USB connection.

### DIFF
--- a/cmd-keypad.c
+++ b/cmd-keypad.c
@@ -59,9 +59,9 @@ int cmd_keypad(int argc, char **argv)
 	int end = 0;
 	uint32_t key_state[18] = {0};
 
-	printf("Press %c on keypad to exit\n",
+	printf("Press %c on keypad or any key on serial to exit\n",
 		key_vals[ARRAY_SIZE(key_vals) - 2]);
-	while (!end) {
+	while (!end && !serial_available()) {
 		int key;
 
 		for (key = 0; key < (ARRAY_SIZE(key_vals) - 1); key++) {

--- a/include/serial.h
+++ b/include/serial.h
@@ -9,6 +9,7 @@ void serial_puth(uint32_t hex, int digits); /* Put hex */
 void serial_write(const void *d, int bytes);
 
 uint8_t serial_getc(void);
+int serial_available(void);
 int serial_print_hex(const void *bfr, int count);
 int serial_read(void *data, int bytes);
 

--- a/serial.c
+++ b/serial.c
@@ -100,6 +100,12 @@ uint8_t serial_getc(void)
 	return uart_getreg(UART_RBR);
 }
 
+/* Return true if there's pending received char */
+int serial_available(void)
+{
+	return uart_getreg(UART_LSR) & 0x01;
+}
+
 int serial_puts(const void *s)
 {
 	const char *str = s;
@@ -277,6 +283,12 @@ uint8_t serial_getc(void)
 
 	recv_size--;
 	return recv_bfr[recv_offset++];
+}
+
+int serial_available(void)
+{
+	usb_handle_irqs(1);
+	return recv_size != 0;
 }
 
 int serial_puts(const void *s)


### PR DESCRIPTION
"keypad" command so far assumes rather adhoc keyboard map, and effectively
locks up otherwise. Allow to break out of it from host connection.